### PR TITLE
Fix/tts await completion event

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Synthesizer Options:
   --SpeechSynthesisOutputFormat     Azure TTS output format. Default: Raw22050Hz16BitMonoPcm
   --DestAudioType                   Audio output type [speaker, file]. Default: speaker
   --DestAudioPath                   Path to audio file. Only used if DestAudioType is File. Default: ./audio
+  --SynthesizerTimeoutMs            Synthesizer timeout. Default: 5000
 
 Analyzer Options:
   --CluKey                      Azure CLU key. Default: 
@@ -146,6 +147,7 @@ Synthesizer:
   SpeechSynthesisOutputFormat: Raw22050Hz16BitMonoPcm
   DestAudioType: file # file or speaker
   DestAudioPath: ./audio # path to either a folder containing audio or a specific audio file
+  SynthesizerTimeoutMs: 5000
 
 Analyzer:
   CluKey: YOUR_CLU_KEY

--- a/appsettings.sample.yaml
+++ b/appsettings.sample.yaml
@@ -31,6 +31,7 @@ Synthesizer:
   SpeechSynthesisOutputFormat: Raw22050Hz16BitMonoPcm
   DestAudioType: file # file or speaker
   DestAudioPath: ./audio # path to either a folder containing audio or a specific audio file
+  SynthesizerTimeoutMs: 5000
 
 Analyzer:
   CluKey: YOUR_CLU_KEY

--- a/src/Models/SynthesizerSettings.cs
+++ b/src/Models/SynthesizerSettings.cs
@@ -18,6 +18,7 @@ namespace SpeechEnabledTvClient.Models
             public const string SpeechSynthesisOutputFormat = "Raw22050Hz16BitMonoPcm";
             public const string DestAudioType = "speaker"; // speaker or file
             public const string DestAudioPath = "./audio"; // path to either a folder containing audio or a specific audio file
+            public const int SynthesizerTimeoutMs = 5000; // 5 seconds
         }
         public string SubscriptionKey { get; set; } = Defaults.SubscriptionKey;
         public string ServiceRegion { get; set; } = Defaults.ServiceRegion;
@@ -25,5 +26,6 @@ namespace SpeechEnabledTvClient.Models
         public string SpeechSynthesisOutputFormat { get; set; } = Defaults.SpeechSynthesisOutputFormat;
         public string DestAudioType { get; set; } = Defaults.DestAudioType;
         public string DestAudioPath { get; set; } = Defaults.DestAudioPath;
+        public int SynthesizerTimeoutMs { get; set; } = Defaults.SynthesizerTimeoutMs;
     }
 }

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -248,6 +248,7 @@ namespace SpeechEnabledTvClient
             Console.WriteLine($"  --SpeechSynthesisOutputFormat     Azure TTS output format. Default: {SynthesizerSettings.Defaults.SpeechSynthesisOutputFormat}");
             Console.WriteLine($"  --DestAudioType                   Audio output type [speaker, file]. Default: {SynthesizerSettings.Defaults.DestAudioType}");
             Console.WriteLine($"  --DestAudioPath                   Path to audio file. Only used if DestAudioType is File. Default: {SynthesizerSettings.Defaults.DestAudioPath}");
+            Console.WriteLine($"  --SynthesizerTimeoutMs            Synthesizer timeout. Default: {SynthesizerSettings.Defaults.SynthesizerTimeoutMs}");
             Console.WriteLine();
             Console.WriteLine("Analyzer Options:");
             Console.WriteLine($"  --CluKey                      Azure CLU key. Default: {AnalyzerSettings.Defaults.CluKey}");

--- a/src/version.cs
+++ b/src/version.cs
@@ -6,5 +6,5 @@ namespace SpeechEnabledTvClient ;
 public class Version {
 
     // The version of the application.
-    public static readonly string version = "0.0.6";
+    public static readonly string version = "0.0.7";
 }


### PR DESCRIPTION
This fixes an intermittent issue where synthesizer's SpeakTextAsync() method is completing before all synthesizer events are triggered, including synthesizing and completed events. This caused audio to not be fully written to audio output.